### PR TITLE
Add DiceService singleton and roll helpers

### DIFF
--- a/src/domain/services/DiceService.ts
+++ b/src/domain/services/DiceService.ts
@@ -1,3 +1,5 @@
+import { DiceType } from '../entities/Dice';
+
 export interface DiceRoll {
   diceType: string; // 'd20', 'd6', etc.
   roll: number;
@@ -17,6 +19,15 @@ export interface DiceCheck {
 }
 
 export class DiceService {
+
+  private static instance: DiceService;
+
+  static getInstance(): DiceService {
+    if (!DiceService.instance) {
+      DiceService.instance = new DiceService();
+    }
+    return DiceService.instance;
+  }
   
   rollDice(sides: number): number {
     return Math.floor(Math.random() * sides) + 1;
@@ -44,6 +55,21 @@ export class DiceService {
 
   rollD12(): number {
     return this.rollDice(12);
+  }
+
+  rollAbilityScore(): number {
+    const rolls = [this.rollD6(), this.rollD6(), this.rollD6(), this.rollD6()];
+    rolls.sort((a, b) => a - b);
+    return rolls.slice(1).reduce((sum, r) => sum + r, 0);
+  }
+
+  rollHitPoints(dice: DiceType, modifier: number): number {
+    const roll = this.rollDice(dice);
+    return Math.max(1, roll + modifier);
+  }
+
+  rollInitiative(modifier: number): number {
+    return this.rollWithModifier(20, modifier).total;
   }
 
   rollWithModifier(sides: number, modifier: number): DiceRoll {


### PR DESCRIPTION
## Summary
- add singleton access for `DiceService`
- implement `rollAbilityScore` using 4d6 drop lowest
- implement `rollHitPoints` and `rollInitiative`
- import `DiceType` for hit point rolls

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b14e10ca48327922758bb5ef43b85