### PR TITLE
Refactor combat roll handling

### DIFF
--- a/src/application/use-cases/CombatUseCase.test.ts
+++ b/src/application/use-cases/CombatUseCase.test.ts
@@ -1,0 +1,57 @@
+import assert from 'assert';
+import { CombatUseCase } from './CombatUseCase';
+import { InMemoryCharacterRepository } from '../../infrastructure/repositories/InMemoryCharacterRepository';
+import { DiceService } from '../../domain/services/DiceService';
+import { Character } from '../../domain/entities/Character';
+import { CharacterClassVO, CharacterClass } from '../../domain/value-objects/CharacterClass';
+import { AbilityScores } from '../../domain/value-objects/AbilityScores';
+import { HitPoints } from '../../domain/value-objects/HitPoints';
+
+(async () => {
+  const repo = new InMemoryCharacterRepository();
+  const dice = DiceService.getInstance();
+  const useCase = new CombatUseCase(repo, dice);
+
+  const attacker = new Character({
+    name: 'Attacker',
+    characterClass: new CharacterClassVO(CharacterClass.FIGHTER),
+    level: 1,
+    abilityScores: new AbilityScores({
+      strength: 18,
+      dexterity: 10,
+      constitution: 10,
+      intelligence: 10,
+      wisdom: 10,
+      charisma: 10,
+    }),
+    hitPoints: new HitPoints(10, 10),
+    armorClass: 10,
+    experience: 0,
+  });
+
+  const target = new Character({
+    name: 'Target',
+    characterClass: new CharacterClassVO(CharacterClass.FIGHTER),
+    level: 1,
+    abilityScores: new AbilityScores({
+      strength: 10,
+      dexterity: 10,
+      constitution: 10,
+      intelligence: 10,
+      wisdom: 10,
+      charisma: 10,
+    }),
+    hitPoints: new HitPoints(10, 10),
+    armorClass: 10,
+    experience: 0,
+  });
+
+  await repo.save(attacker);
+  await repo.save(target);
+
+  const result = await useCase.performAttack(attacker.getId(), target.getId());
+
+  assert.ok(result.attackRoll >= 1 && result.attackRoll <= 40);
+  assert.strictEqual(result.targetAc, 10);
+  console.log('CombatUseCase test passed');
+})();

--- a/src/application/use-cases/CombatUseCase.ts
+++ b/src/application/use-cases/CombatUseCase.ts
@@ -33,14 +33,15 @@ export class CombatUseCase {
     }
 
     const attackBonus = attacker.getAbilityScores().getModifier('strength');
-    const attackRoll = this.diceService.rollAttack(attackBonus);
+    const attackCheck = this.diceService.rollAttack(attackBonus);
+    const attackRoll = attackCheck.roll.total;
     const targetAc = target.getArmorClass();
-    const criticalHit = (attackRoll - attackBonus) === 20;
+    const criticalHit = attackCheck.roll.roll === 20;
     const success = attackRoll >= targetAc || criticalHit;
 
     let damage = 0;
     if (success) {
-      const baseDamage = this.diceService.rollAttack(attackBonus);
+      const baseDamage = this.diceService.rollDamage(1, 8, attackBonus).total;
       damage = criticalHit ? baseDamage * 2 : baseDamage;
       target.takeDamage(damage);
       await this.characterRepository.update(target);


### PR DESCRIPTION
## Summary
- use the full DiceService attack roll result when resolving combat
- compute damage using `rollDamage`
- add a small test script for `CombatUseCase`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687b1618f81c832793e946393a551d1b